### PR TITLE
Add #![feature(buf_stream)] to compile with current nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: rust
 
 rust:
   - nightly
-  - beta
-  - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: rust
 
 rust:
   - nightly
+  - beta
+  - stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@
 //! let _ = email_client.quit();
 //! ```
 
+#![feature(buf_stream)]
 #![deny(missing_docs)]
 
 #[macro_use] extern crate log;


### PR DESCRIPTION
Hi there. This adds a crate level feature attribute to allow it to build on the current nightly.